### PR TITLE
Fixed an error where tagged images that where created as a URL based …

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -193,5 +193,8 @@
   },
   "2.7.0": {
     "en": "Added \"A message from Topic is received\". Thanks to enyineer / nico for programming this!"
+  },
+  "2.7.1": {
+    "en": "Fixed an error where tagged images that where created as a URL based homey image wasn't being followed on redirects"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.spkes.telegramNotifications",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "compatibility": ">=8.1.0",
   "sdk": 3,
   "brandColor": "#229ED9",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.spkes.telegramNotifications",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "compatibility": ">=8.1.0",
   "sdk": 3,
   "brandColor": "#229ED9",

--- a/utils.ts
+++ b/utils.ts
@@ -16,23 +16,28 @@ export default class Utils {
     }
 
     public static async getStatusCode(url: string) {
-        return new Promise((resolve, reject) => {
-            const http = require('http');
-            const https = require('https');
-            let client = http;
-            //Switch to HTTPS
-            if (url.toString().indexOf("https") === 0)
-                client = https;
-
-            //Getting StatusCode
-            client.get(url, (res: IncomingMessage) => {
-                resolve(res.statusCode);
-            }).on("error", (err: any) => {
-                reject(err);
-            });
-        });
+        return new Promise((resolve, reject) => this.redirectFollow(url, resolve, reject));
     }
 
+    public static redirectFollow(url: string, resolve: any, reject: any) {
+        const http = require('http');
+        const https = require('https');
+        let client = http;
+        //Switch to HTTPS
+        if (url.toString().indexOf("https") === 0)
+            client = https;
+
+        client.get(url, (res: IncomingMessage) => {
+            // if url is redirecting follow the redirect else resolve statuscode
+            if(res.statusCode === 301 || res.statusCode === 302) {
+                return this.redirectFollow(res.headers.location as string, resolve, reject)
+            } else {
+                resolve(res.statusCode);
+            }
+        }).on("error", (err: any) => {
+            reject(err);
+        });
+    }
 
     public static userAutocomplete(users: Chat[], query: string, opts?: {
         skipTopics?: boolean,


### PR DESCRIPTION
…homey image wasn't being followed on redirects

https://apps.developer.homey.app/advanced/images#using-an-url
Images set as Using an URL, redirects with a 302 to the source on the internet.
This redirect ended in a reject as it was not a 200 status code.